### PR TITLE
Update internal storage of tree metadata; remove `as_tree_ref`

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,10 +84,31 @@ version = "0.1.1"
 dependencies = [
  "bytemuck",
  "float_next_after",
+ "geo-traits",
  "num-traits",
  "rayon",
  "thiserror",
  "tinyvec",
+]
+
+[[package]]
+name = "geo-traits"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b018fc19fa58202b03f1c809aebe654f7d70fd3887dace34c3d05c11aeb474b5"
+dependencies = [
+ "geo-types",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f47c611187777bbca61ea7aba780213f5f3441fd36294ab333e96cfa791b65"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -109,6 +139,12 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "lock_api"
@@ -177,6 +213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -355,6 +392,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.216"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.216"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "smallvec"

--- a/python/src/kdtree.rs
+++ b/python/src/kdtree.rs
@@ -87,8 +87,7 @@ impl KDTree {
         max_x: f64,
         max_y: f64,
     ) -> Bound<'py, PyArray1<usize>> {
-        let result =
-            py.allow_threads(move || self.0.as_kdtree_ref().range(min_x, min_y, max_x, max_y));
+        let result = py.allow_threads(move || self.0.range(min_x, min_y, max_x, max_y));
         PyArray1::from_vec_bound(py, result)
     }
 
@@ -106,7 +105,7 @@ impl KDTree {
         qy: f64,
         r: f64,
     ) -> Bound<'py, PyArray1<usize>> {
-        let result = py.allow_threads(move || self.0.as_kdtree_ref().within(qx, qy, r));
+        let result = py.allow_threads(move || self.0.within(qx, qy, r));
         PyArray1::from_vec_bound(py, result)
     }
 }

--- a/python/src/rtree.rs
+++ b/python/src/rtree.rs
@@ -306,6 +306,7 @@ impl RTree {
         }
         Ok(())
     }
+
     pub unsafe fn __releasebuffer__(&self, _view: *mut ffi::Py_buffer) {
         // is there anything to do here?
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 /// Enum with all errors in this crate.
 #[derive(Error, Debug)]
 pub enum GeoIndexError {
+    /// General errors
     #[error("General error: {0}")]
     General(String),
 }

--- a/src/indices.rs
+++ b/src/indices.rs
@@ -10,7 +10,7 @@ pub enum MutableIndices<'a> {
 }
 
 impl<'a> MutableIndices<'a> {
-    pub fn new(slice: &'a mut [u8], num_nodes: usize) -> Self {
+    pub(crate) fn new(slice: &'a mut [u8], num_nodes: usize) -> Self {
         if num_nodes < 16384 {
             Self::U16(cast_slice_mut(slice))
         } else {
@@ -21,7 +21,8 @@ impl<'a> MutableIndices<'a> {
 
 impl MutableIndices<'_> {
     #[inline]
-    pub fn bytes_per_element(&self) -> usize {
+    #[allow(dead_code)]
+    pub(crate) fn bytes_per_element(&self) -> usize {
         match self {
             Self::U16(_) => 2,
             Self::U32(_) => 4,
@@ -29,7 +30,7 @@ impl MutableIndices<'_> {
     }
 
     #[inline]
-    pub fn swap(&mut self, a: usize, b: usize) {
+    pub(crate) fn swap(&mut self, a: usize, b: usize) {
         match self {
             Self::U16(arr) => arr.swap(a, b),
             Self::U32(arr) => arr.swap(a, b),
@@ -37,7 +38,8 @@ impl MutableIndices<'_> {
     }
 
     #[inline]
-    pub fn get(&self, index: usize) -> usize {
+    #[allow(dead_code)]
+    pub(crate) fn get(&self, index: usize) -> usize {
         match self {
             Self::U16(arr) => arr[index] as usize,
             Self::U32(arr) => arr[index] as usize,
@@ -45,14 +47,15 @@ impl MutableIndices<'_> {
     }
 
     #[inline]
-    pub fn set(&mut self, index: usize, value: usize) {
+    pub(crate) fn set(&mut self, index: usize, value: usize) {
         match self {
             Self::U16(arr) => arr[index] = value.try_into().unwrap(),
             Self::U32(arr) => arr[index] = value.try_into().unwrap(),
         }
     }
 
-    pub fn split_at_mut(&mut self, mid: usize) -> (MutableIndices, MutableIndices) {
+    #[allow(dead_code)]
+    pub(crate) fn split_at_mut(&mut self, mid: usize) -> (MutableIndices, MutableIndices) {
         match self {
             Self::U16(arr) => {
                 let (left, right) = arr.split_at_mut(mid);
@@ -65,7 +68,7 @@ impl MutableIndices<'_> {
         }
     }
 
-    pub fn chunks_mut(&mut self, chunk_size: usize) -> Vec<MutableIndices> {
+    pub(crate) fn chunks_mut(&mut self, chunk_size: usize) -> Vec<MutableIndices> {
         match self {
             Self::U16(arr) => arr
                 .chunks_mut(chunk_size)
@@ -87,7 +90,7 @@ pub enum Indices<'a> {
 }
 
 impl<'a> Indices<'a> {
-    pub fn new(slice: &'a [u8], num_nodes: usize) -> Self {
+    pub(crate) fn new(slice: &'a [u8], num_nodes: usize) -> Self {
         if num_nodes < 16384 {
             Self::U16(cast_slice(slice))
         } else {

--- a/src/indices.rs
+++ b/src/indices.rs
@@ -5,7 +5,9 @@ use bytemuck::{cast_slice, cast_slice_mut};
 /// A mutable slice of indices that may be either `u16` or `u32`.
 #[derive(Debug)]
 pub enum MutableIndices<'a> {
+    /// Indices stored as a u16 byte slice
     U16(&'a mut [u16]),
+    /// Indices stored as a u32 byte slice
     U32(&'a mut [u32]),
 }
 
@@ -85,7 +87,9 @@ impl MutableIndices<'_> {
 /// A slice of indices that may be either `u16` or `u32`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Indices<'a> {
+    /// Indices stored as a u16 byte slice
     U16(&'a [u16]),
+    /// Indices stored as a u32 byte slice
     U32(&'a [u32]),
 }
 
@@ -100,6 +104,7 @@ impl<'a> Indices<'a> {
 }
 
 impl Indices<'_> {
+    /// The number of indices in this byte slice
     pub fn len(&self) -> usize {
         match self {
             Self::U16(arr) => arr.len(),
@@ -107,10 +112,14 @@ impl Indices<'_> {
         }
     }
 
+    /// Whether this slice is empty
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// A helper to access a single index from this slice.
+    ///
+    /// Values are casted from u16 or u32 to usize.
     #[inline]
     pub fn get(&self, index: usize) -> usize {
         match self {

--- a/src/kdtree/builder.rs
+++ b/src/kdtree/builder.rs
@@ -1,5 +1,4 @@
 use std::cmp;
-use std::marker::PhantomData;
 
 use bytemuck::cast_slice_mut;
 use geo_traits::{CoordTrait, PointTrait};
@@ -7,6 +6,7 @@ use geo_traits::{CoordTrait, PointTrait};
 use crate::error::Result;
 use crate::indices::MutableIndices;
 use crate::kdtree::constants::{KDBUSH_HEADER_SIZE, KDBUSH_MAGIC, KDBUSH_VERSION};
+use crate::kdtree::index::KDTreeMetadata;
 use crate::kdtree::OwnedKDTree;
 use crate::r#type::IndexableNum;
 use crate::GeoIndexError;
@@ -14,20 +14,12 @@ use crate::GeoIndexError;
 const DEFAULT_NODE_SIZE: u16 = 64;
 
 /// A builder to create an [`OwnedKDTree`].
+#[derive(Debug)]
 pub struct KDTreeBuilder<N: IndexableNum> {
     /// data buffer
     data: Vec<u8>,
-
-    num_items: usize,
-    node_size: usize,
-
-    coords_byte_size: usize,
-    indices_byte_size: usize,
-    pad_coords_byte_size: usize,
-
+    metadata: KDTreeMetadata<N>,
     pos: usize,
-
-    phantom: PhantomData<N>,
 }
 
 impl<N: IndexableNum> KDTreeBuilder<N> {
@@ -38,36 +30,21 @@ impl<N: IndexableNum> KDTreeBuilder<N> {
 
     /// Create a new builder with the provided number of items and node size.
     pub fn new_with_node_size(num_items: u32, node_size: u16) -> Self {
-        assert!((2..=65535).contains(&node_size));
+        let metadata = KDTreeMetadata::new(num_items, node_size);
 
-        // The public API uses u32 and u16 types but internally we use usize
-        let num_items = num_items as usize;
-        let node_size = node_size as usize;
-
-        let coords_byte_size = num_items * 2 * N::BYTES_PER_ELEMENT;
-        let indices_bytes_per_element = if num_items < 65536 { 2 } else { 4 };
-        let indices_byte_size = num_items * indices_bytes_per_element;
-        let pad_coords_byte_size = (8 - (indices_byte_size % 8)) % 8;
-
-        let data_buffer_length =
-            KDBUSH_HEADER_SIZE + coords_byte_size + indices_byte_size + pad_coords_byte_size;
+        let data_buffer_length = metadata.data_buffer_length();
         let mut data = vec![0; data_buffer_length];
 
         // Set data header;
         data[0] = KDBUSH_MAGIC;
         data[1] = (KDBUSH_VERSION << 4) + N::TYPE_INDEX;
-        cast_slice_mut(&mut data[2..4])[0] = node_size as u16;
-        cast_slice_mut(&mut data[4..8])[0] = num_items as u32;
+        cast_slice_mut(&mut data[2..4])[0] = node_size;
+        cast_slice_mut(&mut data[4..8])[0] = num_items;
 
         Self {
             data,
-            num_items,
-            node_size,
-            coords_byte_size,
-            indices_byte_size,
-            pad_coords_byte_size,
             pos: 0,
-            phantom: PhantomData,
+            metadata,
         }
     }
 
@@ -77,13 +54,7 @@ impl<N: IndexableNum> KDTreeBuilder<N> {
     #[inline]
     pub fn add(&mut self, x: N, y: N) -> usize {
         let index = self.pos >> 1;
-        let (coords, mut ids) = split_data_borrow(
-            &mut self.data,
-            self.num_items,
-            self.indices_byte_size,
-            self.coords_byte_size,
-            self.pad_coords_byte_size,
-        );
+        let (coords, mut ids) = split_data_borrow(&mut self.data, self.metadata);
 
         ids.set(index, index);
         coords[self.pos] = x;
@@ -121,28 +92,27 @@ impl<N: IndexableNum> KDTreeBuilder<N> {
     pub fn finish(mut self) -> OwnedKDTree<N> {
         assert_eq!(
             self.pos >> 1,
-            self.num_items,
+            self.metadata.num_items,
             "Added {} items when expected {}.",
             self.pos >> 1,
-            self.num_items
+            self.metadata.num_items
         );
 
-        let (coords, mut ids) = split_data_borrow::<N>(
-            &mut self.data,
-            self.num_items,
-            self.indices_byte_size,
-            self.coords_byte_size,
-            self.pad_coords_byte_size,
-        );
+        let (coords, mut ids) = split_data_borrow::<N>(&mut self.data, self.metadata);
 
         // kd-sort both arrays for efficient search
-        sort(&mut ids, coords, self.node_size, 0, self.num_items - 1, 0);
+        sort(
+            &mut ids,
+            coords,
+            self.metadata.node_size,
+            0,
+            self.metadata.num_items - 1,
+            0,
+        );
 
         OwnedKDTree {
             buffer: self.data,
-            node_size: self.node_size,
-            num_items: self.num_items,
-            phantom: PhantomData,
+            metadata: self.metadata,
         }
     }
 }
@@ -150,16 +120,14 @@ impl<N: IndexableNum> KDTreeBuilder<N> {
 /// Mutable borrow of coords and ids
 fn split_data_borrow<N: IndexableNum>(
     data: &mut [u8],
-    num_items: usize,
-    indices_byte_size: usize,
-    coords_byte_size: usize,
-    pad_coords: usize,
+    metadata: KDTreeMetadata<N>,
 ) -> (&mut [N], MutableIndices) {
-    let (ids_buf, padded_coords_buf) = data[KDBUSH_HEADER_SIZE..].split_at_mut(indices_byte_size);
-    let coords_buf = &mut padded_coords_buf[pad_coords..];
-    debug_assert_eq!(coords_buf.len(), coords_byte_size);
+    let (ids_buf, padded_coords_buf) =
+        data[KDBUSH_HEADER_SIZE..].split_at_mut(metadata.indices_byte_size);
+    let coords_buf = &mut padded_coords_buf[metadata.pad_coords_byte_size..];
+    debug_assert_eq!(coords_buf.len(), metadata.coords_byte_size);
 
-    let ids = if num_items < 65536 {
+    let ids = if metadata.num_items < 65536 {
         MutableIndices::U16(cast_slice_mut(ids_buf))
     } else {
         MutableIndices::U32(cast_slice_mut(ids_buf))

--- a/src/kdtree/index.rs
+++ b/src/kdtree/index.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use bytemuck::cast_slice;
@@ -153,7 +152,7 @@ impl<N: IndexableNum> AsRef<[u8]> for OwnedKDTree<N> {
 pub struct KDTreeRef<'a, N: IndexableNum> {
     pub(crate) coords: &'a [N],
     pub(crate) indices: Indices<'a>,
-    pub(crate) metadata: Cow<'a, KDTreeMetadata<N>>,
+    pub(crate) metadata: KDTreeMetadata<N>,
 }
 
 impl<'a, N: IndexableNum> KDTreeRef<'a, N> {
@@ -172,7 +171,7 @@ impl<'a, N: IndexableNum> KDTreeRef<'a, N> {
         Ok(Self {
             coords,
             indices,
-            metadata: Cow::Owned(metadata),
+            metadata,
         })
     }
 }

--- a/src/kdtree/index.rs
+++ b/src/kdtree/index.rs
@@ -1,56 +1,48 @@
+use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use bytemuck::cast_slice;
 
-use crate::error::GeoIndexError;
+use crate::error::{GeoIndexError, Result};
 use crate::indices::Indices;
 use crate::kdtree::constants::{KDBUSH_HEADER_SIZE, KDBUSH_MAGIC, KDBUSH_VERSION};
 use crate::r#type::IndexableNum;
 
-/// An owned KDTree buffer.
-///
-/// Usually this will be created from scratch via [`KDTreeBuilder`][crate::kdtree::KDTreeBuilder].
-#[derive(Debug, Clone, PartialEq)]
-pub struct OwnedKDTree<N: IndexableNum> {
-    pub(crate) buffer: Vec<u8>,
-    pub(crate) node_size: usize,
-    pub(crate) num_items: usize,
-    pub(crate) phantom: PhantomData<N>,
-}
-
-impl<N: IndexableNum> OwnedKDTree<N> {
-    pub fn into_inner(self) -> Vec<u8> {
-        self.buffer
-    }
-
-    pub fn as_kdtree_ref(&self) -> KDTreeRef<N> {
-        KDTreeRef::try_new(self).unwrap()
-    }
-}
-
-impl<N: IndexableNum> AsRef<[u8]> for OwnedKDTree<N> {
-    fn as_ref(&self) -> &[u8] {
-        &self.buffer
-    }
-}
-
-/// A reference on an external KDTree buffer.
-///
-/// Usually this will be created from an [`OwnedKDTree`] via its [`as_ref`][OwnedKDTree::as_ref]
-/// method, but it can also be created from any existing data buffer.
+/// Common metadata to describe a KDTree
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct KDTreeRef<'a, N: IndexableNum> {
-    pub(crate) coords: &'a [N],
-    pub(crate) ids: Indices<'a>,
+pub(crate) struct KDTreeMetadata<N: IndexableNum> {
     pub(crate) node_size: usize,
     pub(crate) num_items: usize,
+    phantom: PhantomData<N>,
+    pub(crate) indices_byte_size: usize,
+    pub(crate) pad_coords_byte_size: usize,
+    pub(crate) coords_byte_size: usize,
 }
 
-impl<'a, N: IndexableNum> KDTreeRef<'a, N> {
-    pub fn try_new<T: AsRef<[u8]>>(data: &'a T) -> Result<Self, GeoIndexError> {
-        let data = data.as_ref();
-        // TODO: validate length of slice?
+impl<N: IndexableNum> KDTreeMetadata<N> {
+    pub(crate) fn new(num_items: u32, node_size: u16) -> Self {
+        assert!((2..=65535).contains(&node_size));
 
+        // The public API uses u32 and u16 types but internally we use usize
+        let num_items = num_items as usize;
+        let node_size = node_size as usize;
+
+        let coords_byte_size = num_items * 2 * N::BYTES_PER_ELEMENT;
+        let indices_bytes_per_element = if num_items < 65536 { 2 } else { 4 };
+        let indices_byte_size = num_items * indices_bytes_per_element;
+        let pad_coords_byte_size = (8 - (indices_byte_size % 8)) % 8;
+
+        Self {
+            node_size,
+            num_items,
+            phantom: PhantomData,
+            indices_byte_size,
+            pad_coords_byte_size,
+            coords_byte_size,
+        }
+    }
+
+    fn try_new_from_slice(data: &[u8]) -> Result<Self> {
         if data[0] != KDBUSH_MAGIC {
             return Err(GeoIndexError::General(
                 "Data not in Kdbush format.".to_string(),
@@ -79,34 +71,108 @@ impl<'a, N: IndexableNum> KDTreeRef<'a, N> {
 
         let node_size: u16 = cast_slice(&data[2..4])[0];
         let num_items: u32 = cast_slice(&data[4..8])[0];
+
         let node_size = node_size as usize;
         let num_items = num_items as usize;
 
         let coords_byte_size = num_items * 2 * N::BYTES_PER_ELEMENT;
         let indices_bytes_per_element = if num_items < 65536 { 2 } else { 4 };
-        let ids_byte_size = num_items * indices_bytes_per_element;
-        let pad_coords_byte_size = (8 - (ids_byte_size % 8)) % 8;
+        let indices_byte_size = num_items * indices_bytes_per_element;
+        let pad_coords_byte_size = (8 - (indices_byte_size % 8)) % 8;
 
         let data_buffer_length =
-            KDBUSH_HEADER_SIZE + coords_byte_size + ids_byte_size + pad_coords_byte_size;
+            KDBUSH_HEADER_SIZE + coords_byte_size + indices_byte_size + pad_coords_byte_size;
         assert_eq!(data.len(), data_buffer_length);
 
-        let indices_buf = &data[KDBUSH_HEADER_SIZE..KDBUSH_HEADER_SIZE + ids_byte_size];
-        let ids = if num_items < 65536 {
+        Ok(Self {
+            node_size,
+            num_items,
+            phantom: PhantomData,
+            indices_byte_size,
+            pad_coords_byte_size,
+            coords_byte_size,
+        })
+    }
+
+    pub(crate) fn data_buffer_length(&self) -> usize {
+        KDBUSH_HEADER_SIZE
+            + self.coords_byte_size
+            + self.indices_byte_size
+            + self.pad_coords_byte_size
+    }
+
+    pub(crate) fn coords_slice<'a>(&self, data: &'a [u8]) -> &'a [N] {
+        let coords_byte_start =
+            KDBUSH_HEADER_SIZE + self.indices_byte_size + self.pad_coords_byte_size;
+        let coords_byte_end = KDBUSH_HEADER_SIZE
+            + self.indices_byte_size
+            + self.pad_coords_byte_size
+            + self.coords_byte_size;
+        cast_slice(&data[coords_byte_start..coords_byte_end])
+    }
+
+    pub(crate) fn indices_slice<'a>(&self, data: &'a [u8]) -> Indices<'a> {
+        let indices_buf = &data[KDBUSH_HEADER_SIZE..KDBUSH_HEADER_SIZE + self.indices_byte_size];
+
+        if self.num_items < 65536 {
             Indices::U16(cast_slice(indices_buf))
         } else {
             Indices::U32(cast_slice(indices_buf))
-        };
-        let coords_byte_start = KDBUSH_HEADER_SIZE + ids_byte_size + pad_coords_byte_size;
-        let coords_byte_end =
-            KDBUSH_HEADER_SIZE + ids_byte_size + pad_coords_byte_size + coords_byte_size;
-        let coords = cast_slice(&data[coords_byte_start..coords_byte_end]);
+        }
+    }
+}
+
+/// An owned KDTree buffer.
+///
+/// Usually this will be created from scratch via [`KDTreeBuilder`][crate::kdtree::KDTreeBuilder].
+#[derive(Debug, Clone, PartialEq)]
+pub struct OwnedKDTree<N: IndexableNum> {
+    pub(crate) buffer: Vec<u8>,
+    pub(crate) metadata: KDTreeMetadata<N>,
+}
+
+impl<N: IndexableNum> OwnedKDTree<N> {
+    /// Consume this KDTree, returning the underlying buffer.
+    pub fn into_inner(self) -> Vec<u8> {
+        self.buffer
+    }
+}
+
+impl<N: IndexableNum> AsRef<[u8]> for OwnedKDTree<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.buffer
+    }
+}
+
+/// A reference on an external KDTree buffer.
+///
+/// This will often be created from an [`OwnedKDTree`] via its
+/// [`as_kdtree_ref`][OwnedKDTree::as_kdtree_ref] method, but it can also be created from any
+/// existing data buffer.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KDTreeRef<'a, N: IndexableNum> {
+    pub(crate) coords: &'a [N],
+    pub(crate) indices: Indices<'a>,
+    pub(crate) metadata: Cow<'a, KDTreeMetadata<N>>,
+}
+
+impl<'a, N: IndexableNum> KDTreeRef<'a, N> {
+    /// Construct a new KDTreeRef from an external byte slice.
+    ///
+    /// This byte slice must conform to the "kdbush ABI", that is, the ABI originally implemented
+    /// by the JavaScript [`kdbush` library](https://github.com/mourner/kdbush). You can extract
+    /// such a buffer either via [`OwnedKDTree::into_inner`] or from the `.data` attribute of the
+    /// JavaScript `KDBush` object.
+    pub fn try_new<T: AsRef<[u8]>>(data: &'a T) -> Result<Self> {
+        let data = data.as_ref();
+        let metadata = KDTreeMetadata::try_new_from_slice(data)?;
+        let coords = metadata.coords_slice(data);
+        let indices = metadata.indices_slice(data);
 
         Ok(Self {
             coords,
-            ids,
-            node_size,
-            num_items,
+            indices,
+            metadata: Cow::Owned(metadata),
         })
     }
 }

--- a/src/kdtree/mod.rs
+++ b/src/kdtree/mod.rs
@@ -1,5 +1,7 @@
 //! An implementation of an immutable, ABI-stable K-D Tree.
 
+#![warn(missing_docs)]
+
 mod builder;
 pub(crate) mod constants;
 mod index;

--- a/src/kdtree/mod.rs
+++ b/src/kdtree/mod.rs
@@ -1,7 +1,5 @@
 //! An implementation of an immutable, ABI-stable K-D Tree.
 
-#![warn(missing_docs)]
-
 mod builder;
 pub(crate) mod constants;
 mod index;

--- a/src/kdtree/test.rs
+++ b/src/kdtree/test.rs
@@ -149,9 +149,8 @@ fn make_index() -> OwnedKDTree<f64> {
 
 #[test]
 fn creates_an_index() {
-    let owned_index = make_index();
-    let kdbush = owned_index.as_kdtree_ref();
-    let tree_ids = kdbush.ids();
+    let kdbush = make_index();
+    let tree_ids = kdbush.indices();
     let tree_ids = match tree_ids {
         Indices::U16(arr) => arr,
         _ => unimplemented!(),
@@ -167,8 +166,7 @@ fn creates_an_index() {
 
 #[test]
 fn range_search() {
-    let owned_index = make_index();
-    let kdbush = owned_index.as_kdtree_ref();
+    let kdbush = make_index();
 
     let min_x = 20.;
     let min_y = 30.;
@@ -204,8 +202,7 @@ fn range_search() {
 
 #[test]
 fn radius_search() {
-    let owned_index = make_index();
-    let kdbush = owned_index.as_kdtree_ref();
+    let kdbush = make_index();
 
     let [qx, qy] = [50., 50.];
     let r = 20.;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
 
 mod error;
 pub mod indices;

--- a/src/rtree/index.rs
+++ b/src/rtree/index.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use bytemuck::cast_slice;
@@ -153,7 +152,7 @@ impl<N: IndexableNum> AsRef<[u8]> for OwnedRTree<N> {
 pub struct RTreeRef<'a, N: IndexableNum> {
     pub(crate) boxes: &'a [N],
     pub(crate) indices: Indices<'a>,
-    pub(crate) metadata: Cow<'a, RTreeMetadata<N>>,
+    pub(crate) metadata: RTreeMetadata<N>,
 }
 
 impl<'a, N: IndexableNum> RTreeRef<'a, N> {
@@ -172,7 +171,7 @@ impl<'a, N: IndexableNum> RTreeRef<'a, N> {
         Ok(Self {
             boxes,
             indices,
-            metadata: Cow::Owned(metadata),
+            metadata,
         })
     }
 }

--- a/src/rtree/index.rs
+++ b/src/rtree/index.rs
@@ -7,7 +7,6 @@ use crate::error::{GeoIndexError, Result};
 use crate::indices::Indices;
 use crate::r#type::IndexableNum;
 use crate::rtree::constants::VERSION;
-use crate::rtree::r#trait::RTreeIndex;
 use crate::rtree::util::compute_num_nodes;
 
 /// Common metadata to describe an RTree
@@ -139,15 +138,6 @@ impl<N: IndexableNum> OwnedRTree<N> {
 
     pub fn into_inner(self) -> Vec<u8> {
         self.buffer
-    }
-
-    // TODO: remove
-    pub fn as_rtree_ref(&self) -> RTreeRef<N> {
-        RTreeRef {
-            boxes: self.boxes(),
-            indices: self.indices(),
-            metadata: Cow::Borrowed(&self.metadata),
-        }
     }
 }
 

--- a/src/rtree/index.rs
+++ b/src/rtree/index.rs
@@ -131,11 +131,6 @@ pub struct OwnedRTree<N: IndexableNum> {
 }
 
 impl<N: IndexableNum> OwnedRTree<N> {
-    pub fn try_new(buffer: Vec<u8>) -> Result<Self> {
-        let metadata = RTreeMetadata::try_new_from_slice(&buffer)?;
-        Ok(Self { buffer, metadata })
-    }
-
     pub fn into_inner(self) -> Vec<u8> {
         self.buffer
     }

--- a/src/rtree/index.rs
+++ b/src/rtree/index.rs
@@ -131,6 +131,9 @@ pub struct OwnedRTree<N: IndexableNum> {
 }
 
 impl<N: IndexableNum> OwnedRTree<N> {
+    /// Access the underlying buffer of this RTree.
+    ///
+    /// This buffer can then be persisted and passed to `RTreeRef::try_new`.
     pub fn into_inner(self) -> Vec<u8> {
         self.buffer
     }
@@ -154,6 +157,12 @@ pub struct RTreeRef<'a, N: IndexableNum> {
 }
 
 impl<'a, N: IndexableNum> RTreeRef<'a, N> {
+    /// Construct a new RTree from an external byte slice.
+    ///
+    /// This byte slice must conform to the "flatbush ABI", that is, the ABI originally implemented
+    /// by the JavaScript [`flatbush` library](https://github.com/mourner/flatbush). You can
+    /// extract such a buffer either via [`OwnedRTree::into_inner`] or from the `.data` attribute
+    /// of the JavaScript `Flatbush` object.
     pub fn try_new<T: AsRef<[u8]>>(data: &'a T) -> Result<Self> {
         let data = data.as_ref();
         let metadata = RTreeMetadata::try_new_from_slice(data)?;

--- a/src/rtree/sort/trait.rs
+++ b/src/rtree/sort/trait.rs
@@ -3,11 +3,17 @@ use crate::r#type::IndexableNum;
 
 /// Parameters that are passed in to the `sort` function of the `Sort` trait.
 pub struct SortParams<N: IndexableNum> {
+    /// The number of items in this RTree
     pub num_items: usize,
+    /// The node size of this RTree
     pub node_size: usize,
+    /// The global min_x of this RTree
     pub min_x: N,
+    /// The global min_y of this RTree
     pub min_y: N,
+    /// The global max_x of this RTree
     pub max_x: N,
+    /// The global max_y of this RTree
     pub max_y: N,
 }
 

--- a/src/rtree/trait.rs
+++ b/src/rtree/trait.rs
@@ -7,6 +7,7 @@ use crate::rtree::index::{OwnedRTree, RTreeRef};
 use crate::rtree::traversal::{IntersectionIterator, Node};
 use crate::GeoIndexError;
 
+/// A trait for searching and accessing data out of an RTree.
 pub trait RTreeIndex<N: IndexableNum>: Sized {
     /// A slice representing all the bounding boxes of all elements contained within this tree,
     /// including the bounding boxes of each internal node.

--- a/src/type.rs
+++ b/src/type.rs
@@ -70,6 +70,7 @@ impl IndexableNum for f64 {
 }
 
 /// An enum over the allowed coordinate types in the spatial index.
+#[allow(missing_docs)]
 pub enum CoordType {
     Int8,
     UInt8,


### PR DESCRIPTION
### Change list

- (breaking) Remove public methods from `MutableIndices`
- (breaking) Remove `as_kdtree_ref` from `OwnedKDTree`. `OwnedKDTree` now implements `KDTreeIndex` directly.
- Implement `KDTreeIndex` for `OwnedKDTree`
- Consolidate metadata into KDTreeMetadata and RTreeMetadata, and use that for indexes and builders.
- Disallow missing docs