### PR TITLE
KDTree traversal

### DIFF
--- a/src/kdtree/mod.rs
+++ b/src/kdtree/mod.rs
@@ -53,10 +53,12 @@ mod builder;
 pub(crate) mod constants;
 mod index;
 mod r#trait;
+mod traversal;
 
 pub use builder::{KDTreeBuilder, DEFAULT_KDTREE_NODE_SIZE};
 pub use index::{KDTree, KDTreeMetadata, KDTreeRef};
 pub use r#trait::KDTreeIndex;
+pub use traversal::Node;
 
 #[cfg(test)]
 mod test;

--- a/src/kdtree/traversal.rs
+++ b/src/kdtree/traversal.rs
@@ -1,0 +1,156 @@
+//! Utilities to traverse the KDTree structure.
+
+use geo_traits::RectTrait;
+
+use crate::kdtree::KDTreeIndex;
+use crate::r#type::{Coord, IndexableNum};
+use std::marker::PhantomData;
+
+/// An internal node in the KDTree.
+#[derive(Debug, Clone)]
+pub struct Node<'a, N: IndexableNum, T: KDTreeIndex<N>> {
+    /// The tree that this node is a reference onto
+    tree: &'a T,
+
+    /// The axis that the children of this node are split over.
+    /// 0 for x axis, 1 for y axis
+    /// TODO: switch to bool
+    axis: usize,
+
+    right_child: usize,
+    left_child: usize,
+
+    phantom: PhantomData<N>,
+
+    min_x: N,
+    min_y: N,
+    max_x: N,
+    max_y: N,
+}
+
+impl<'a, N: IndexableNum, T: KDTreeIndex<N>> Node<'a, N, T> {
+    pub(crate) fn from_root(tree: &'a T) -> Self {
+        Self {
+            tree,
+            axis: 0,
+            right_child: tree.indices().len() - 1,
+            left_child: 0,
+            phantom: PhantomData,
+            min_x: N::max_value(),
+            min_y: N::max_value(),
+            max_x: N::min_value(),
+            max_y: N::min_value(),
+        }
+    }
+
+    // TODO: perhaps this should be state stored on the node, so we don't have to recompute it
+    // But it's only valid for nodes that have children
+    /// Note: this is the index into the coords array, not the insertion index.
+    #[inline]
+    pub(crate) fn middle_index(&self) -> usize {
+        (self.left_child + self.right_child) >> 1
+    }
+
+    // TODO: perhaps this should be state stored on the node, so we don't have to recompute it
+    // But it's only valid for nodes that have children
+    #[inline]
+    pub(crate) fn middle_xy(&self, m: usize) -> (N, N) {
+        let x = self.tree.coords()[2 * m];
+        let y = self.tree.coords()[2 * m + 1];
+        (x, y)
+    }
+
+    /// The child node representing the "left" half.
+    ///
+    /// Note that this **does not include** the middle index of the current node.
+    pub fn left_child(&self) -> Node<'_, N, T> {
+        let m = self.middle_index();
+        let (x, y) = self.middle_xy(m);
+
+        let mut max_x = self.max_x;
+        let mut max_y = self.max_y;
+        if self.axis == 0 {
+            max_x = x;
+        } else {
+            max_y = y;
+        };
+
+        Self {
+            tree: self.tree,
+            axis: 1 - self.axis,
+            right_child: m - 1,
+            left_child: self.left_child,
+            min_x: self.min_x,
+            min_y: self.min_y,
+            max_x,
+            max_y,
+            phantom: self.phantom,
+        }
+    }
+
+    /// The child node representing the "right" half.
+    ///
+    /// Note that this **does not include** the middle index of the current node.
+    pub fn right_child(&self) -> Node<'_, N, T> {
+        let m = self.middle_index();
+        let (x, y) = self.middle_xy(m);
+
+        let mut min_x = self.min_x;
+        let mut min_y = self.min_y;
+        if self.axis == 0 {
+            min_x = x;
+        } else {
+            min_y = y;
+        };
+
+        Self {
+            tree: self.tree,
+            axis: 1 - self.axis,
+            right_child: self.right_child,
+            left_child: m + 1,
+            min_x,
+            min_y,
+            max_x: self.max_x,
+            max_y: self.max_y,
+            phantom: self.phantom,
+        }
+    }
+
+    /// Returns `true` if this is a leaf node without children.
+    #[inline]
+    pub fn is_leaf(&self) -> bool {
+        self.right_child - self.left_child <= self.tree.node_size() as usize
+    }
+
+    /// Returns `true` if this is an intermediate node with children.
+    #[inline]
+    pub fn is_parent(&self) -> bool {
+        !self.is_leaf()
+    }
+}
+
+impl<N: IndexableNum, T: KDTreeIndex<N>> RectTrait for Node<'_, N, T> {
+    type T = N;
+    type CoordType<'a>
+        = Coord<N>
+    where
+        Self: 'a;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        geo_traits::Dimensions::Xy
+    }
+
+    fn min(&self) -> Self::CoordType<'_> {
+        Coord {
+            x: self.min_x,
+            y: self.min_y,
+        }
+    }
+
+    fn max(&self) -> Self::CoordType<'_> {
+        Coord {
+            x: self.max_x,
+            y: self.max_y,
+        }
+    }
+}

--- a/src/rtree/mod.rs
+++ b/src/rtree/mod.rs
@@ -59,9 +59,10 @@ mod constants;
 mod index;
 pub mod sort;
 mod r#trait;
-pub mod traversal;
+mod traversal;
 pub mod util;
 
 pub use builder::{RTreeBuilder, DEFAULT_RTREE_NODE_SIZE};
 pub use index::{RTree, RTreeMetadata, RTreeRef};
 pub use r#trait::RTreeIndex;
+pub use traversal::Node;

--- a/src/rtree/traversal.rs
+++ b/src/rtree/traversal.rs
@@ -1,8 +1,8 @@
 //! Utilities to traverse the RTree structure.
 
-use geo_traits::{CoordTrait, RectTrait};
+use geo_traits::RectTrait;
 
-use crate::r#type::IndexableNum;
+use crate::r#type::{Coord, IndexableNum};
 use crate::rtree::util::upper_bound;
 use crate::rtree::RTreeIndex;
 use core::mem::take;
@@ -51,36 +51,43 @@ impl<'a, N: IndexableNum, T: RTreeIndex<N>> Node<'a, N, T> {
     }
 
     /// Get the minimum `x` value of this node.
+    #[inline]
     pub fn min_x(&self) -> N {
         self.tree.boxes()[self.pos]
     }
 
     /// Get the minimum `y` value of this node.
+    #[inline]
     pub fn min_y(&self) -> N {
         self.tree.boxes()[self.pos + 1]
     }
 
     /// Get the maximum `x` value of this node.
+    #[inline]
     pub fn max_x(&self) -> N {
         self.tree.boxes()[self.pos + 2]
     }
 
     /// Get the maximum `y` value of this node.
+    #[inline]
     pub fn max_y(&self) -> N {
         self.tree.boxes()[self.pos + 3]
     }
 
     /// Returns `true` if this is a leaf node without children.
+    #[inline]
     pub fn is_leaf(&self) -> bool {
         self.pos < self.tree.num_items() as usize * 4
     }
 
     /// Returns `true` if this is an intermediate node with children.
+    #[inline]
     pub fn is_parent(&self) -> bool {
         !self.is_leaf()
     }
 
     /// Returns `true` if this node intersects another node.
+    #[inline]
     pub fn intersects<T2: RTreeIndex<N>>(&self, other: &Node<N, T2>) -> bool {
         if self.max_x() < other.min_x() {
             return false;
@@ -118,41 +125,10 @@ impl<'a, N: IndexableNum, T: RTreeIndex<N>> Node<'a, N, T> {
 
     /// The original insertion index. This is only valid when this is a leaf node, which you can
     /// check with `Self::is_leaf`.
+    #[inline]
     pub fn index(&self) -> usize {
         debug_assert!(self.is_leaf());
         self.tree.indices().get(self.pos >> 2)
-    }
-}
-
-/// A single coordinate.
-///
-/// Used in the implementation of RectTrait for Node.
-pub struct Coord<N: IndexableNum> {
-    x: N,
-    y: N,
-}
-
-impl<N: IndexableNum> CoordTrait for Coord<N> {
-    type T = N;
-
-    fn dim(&self) -> geo_traits::Dimensions {
-        geo_traits::Dimensions::Xy
-    }
-
-    fn x(&self) -> Self::T {
-        self.x
-    }
-
-    fn y(&self) -> Self::T {
-        self.y
-    }
-
-    fn nth_or_panic(&self, n: usize) -> Self::T {
-        match n {
-            0 => self.x,
-            1 => self.y,
-            _ => panic!("Invalid index of coord"),
-        }
     }
 }
 

--- a/src/type.rs
+++ b/src/type.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use geo_traits::CoordTrait;
 use num_traits::{Bounded, Num, NumCast};
 
 use crate::kdtree::constants::KDBUSH_MAGIC;
@@ -139,4 +140,36 @@ mod private {
     impl Sealed for u32 {}
     impl Sealed for f32 {}
     impl Sealed for f64 {}
+}
+
+/// A single coordinate.
+///
+/// Used in the implementation of RectTrait for Node.
+pub struct Coord<N: IndexableNum> {
+    pub(crate) x: N,
+    pub(crate) y: N,
+}
+
+impl<N: IndexableNum> CoordTrait for Coord<N> {
+    type T = N;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        geo_traits::Dimensions::Xy
+    }
+
+    fn x(&self) -> Self::T {
+        self.x
+    }
+
+    fn y(&self) -> Self::T {
+        self.y
+    }
+
+    fn nth_or_panic(&self, n: usize) -> Self::T {
+        match n {
+            0 => self.x,
+            1 => self.y,
+            _ => panic!("Invalid index of coord"),
+        }
+    }
 }


### PR DESCRIPTION
### Change list

- Add `kdtree::Node` for traversing a kdtree.
- Make checked variants of accessing children and insertion indices.
- Inline rtree and kdtree accessors.
- Return `u32` instead of `usize` for insertion index.
- Move `Coord` to be unexported

For https://github.com/kylebarron/geo-index/issues/68. Still need to follow up with a way to get the actual _partitioning structure_ of a kdtree.