### PR TITLE
Upgrade geo-traits to 0.3.0; upgrade geo to 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 **This is the changelog for the core Rust library**. There's a [separate changelog](./python/CHANGELOG.md) for the Python bindings.
 
+## [0.3.0] - <RELEASE DATE>
+
+### Breaking
+
+- Upgrade geo-traits to 0.3 by @kontinuation in https://github.com/kylebarron/geo-index/pull/127
+- Update geo to 0.30.0 by @kontinuation in https://github.com/kylebarron/geo-index/pull/127
+
 ## [0.2.0] - 2025-01-06
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,18 +20,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,14 +438,15 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
+checksum = "4416397671d8997e9a3e7ad99714f4f00a22e9eaa9b966a5985d2194fc9e02e1"
 dependencies = [
  "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
+ "i_overlay",
  "log",
  "num-traits",
  "robust",
@@ -479,21 +474,22 @@ dependencies = [
 
 [[package]]
 name = "geo-traits"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b018fc19fa58202b03f1c809aebe654f7d70fd3887dace34c3d05c11aeb474b5"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
 dependencies = [
  "geo-types",
 ]
 
 [[package]]
 name = "geo-types"
-version = "0.7.14"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f47c611187777bbca61ea7aba780213f5f3441fd36294ab333e96cfa791b65"
+checksum = "62ddb1950450d67efee2bbc5e429c68d052a822de3aad010d28b351fbb705224"
 dependencies = [
  "approx",
  "num-traits",
+ "rayon",
  "rstar",
  "serde",
 ]
@@ -561,19 +557,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heapless"
@@ -601,13 +592,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "i_float"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85df3a416829bb955fdc2416c7b73680c8dcea8d731f2c7aa23e1042fe1b8343"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
+
+[[package]]
+name = "i_overlay"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0542dfef184afdd42174a03dcc0625b6147fb73e1b974b1a08a2a42ac35cee49"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a38f5a42678726718ff924f6d4a0e79b129776aeed298f71de4ceedbd091bce"
+dependencies = [
+ "i_float",
+ "serde",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155181bc97d770181cf9477da51218a19ee92a8e5be642e796661aee2b601139"
+
+[[package]]
 name = "indexmap"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -873,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -883,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1027,17 +1062,17 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spade"
-version = "2.8.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b20a809169ae442497e41a997fc5f14e2eea04e6ac590816a910d5d8068c8c0"
+checksum = "1ece03ff43cd2a9b57ebf776ea5e78bd30b3b4185a619f041079f4109f385034"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
  "num-traits",
  "robust",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["data-structures", "algorithms", "science::geo"]
 [dependencies]
 bytemuck = "1"
 float_next_after = "1"
-geo-traits = "0.2"
+geo-traits = "0.3"
 num-traits = "0.2"
 rayon = { version = "1.8.0", optional = true }
 thiserror = "1"
@@ -23,11 +23,10 @@ tinyvec = { version = "1", features = ["alloc", "rustc_1_40"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-geo = "0.28.0"
+geo = "0.30.0"
 geozero = "0.12"
 rstar = "0.12"
 zip = "2.2.2"
-
 
 [[bench]]
 name = "rtree"

--- a/src/kdtree/traversal.rs
+++ b/src/kdtree/traversal.rs
@@ -1,6 +1,10 @@
 //! Utilities to traverse the KDTree structure.
 
-use geo_traits::RectTrait;
+use geo_traits::{
+    GeometryTrait, RectTrait, UnimplementedGeometryCollection, UnimplementedLine,
+    UnimplementedLineString, UnimplementedMultiLineString, UnimplementedMultiPoint,
+    UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedPolygon, UnimplementedTriangle,
+};
 
 use crate::kdtree::KDTreeIndex;
 use crate::r#type::{Coord, IndexableNum};
@@ -216,15 +220,10 @@ impl<'a, N: IndexableNum, T: KDTreeIndex<N>> Node<'a, N, T> {
 }
 
 impl<N: IndexableNum, T: KDTreeIndex<N>> RectTrait for Node<'_, N, T> {
-    type T = N;
     type CoordType<'a>
         = Coord<N>
     where
         Self: 'a;
-
-    fn dim(&self) -> geo_traits::Dimensions {
-        geo_traits::Dimensions::Xy
-    }
 
     fn min(&self) -> Self::CoordType<'_> {
         Coord {
@@ -238,5 +237,81 @@ impl<N: IndexableNum, T: KDTreeIndex<N>> RectTrait for Node<'_, N, T> {
             x: self.max_x,
             y: self.max_y,
         }
+    }
+}
+
+impl<N: IndexableNum, T: KDTreeIndex<N>> GeometryTrait for Node<'_, N, T> {
+    type T = N;
+
+    type PointType<'a>
+        = UnimplementedPoint<N>
+    where
+        Self: 'a;
+
+    type LineStringType<'a>
+        = UnimplementedLineString<N>
+    where
+        Self: 'a;
+
+    type PolygonType<'a>
+        = UnimplementedPolygon<N>
+    where
+        Self: 'a;
+
+    type MultiPointType<'a>
+        = UnimplementedMultiPoint<N>
+    where
+        Self: 'a;
+
+    type MultiLineStringType<'a>
+        = UnimplementedMultiLineString<N>
+    where
+        Self: 'a;
+
+    type MultiPolygonType<'a>
+        = UnimplementedMultiPolygon<N>
+    where
+        Self: 'a;
+
+    type GeometryCollectionType<'a>
+        = UnimplementedGeometryCollection<N>
+    where
+        Self: 'a;
+
+    type RectType<'a>
+        = Node<'a, N, T>
+    where
+        Self: 'a;
+
+    type TriangleType<'a>
+        = UnimplementedTriangle<N>
+    where
+        Self: 'a;
+
+    type LineType<'a>
+        = UnimplementedLine<N>
+    where
+        Self: 'a;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        geo_traits::Dimensions::Xy
+    }
+
+    fn as_type(
+        &self,
+    ) -> geo_traits::GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        geo_traits::GeometryType::Rect(self)
     }
 }

--- a/src/rtree/traversal.rs
+++ b/src/rtree/traversal.rs
@@ -1,6 +1,10 @@
 //! Utilities to traverse the RTree structure.
 
-use geo_traits::RectTrait;
+use geo_traits::{
+    GeometryTrait, RectTrait, UnimplementedGeometryCollection, UnimplementedLine,
+    UnimplementedLineString, UnimplementedMultiLineString, UnimplementedMultiPoint,
+    UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedPolygon, UnimplementedTriangle,
+};
 
 use crate::r#type::{Coord, IndexableNum};
 use crate::rtree::util::upper_bound;
@@ -157,15 +161,10 @@ impl<'a, N: IndexableNum, T: RTreeIndex<N>> Node<'a, N, T> {
 }
 
 impl<N: IndexableNum, T: RTreeIndex<N>> RectTrait for Node<'_, N, T> {
-    type T = N;
     type CoordType<'a>
         = Coord<N>
     where
         Self: 'a;
-
-    fn dim(&self) -> geo_traits::Dimensions {
-        geo_traits::Dimensions::Xy
-    }
 
     fn min(&self) -> Self::CoordType<'_> {
         Coord {
@@ -179,6 +178,82 @@ impl<N: IndexableNum, T: RTreeIndex<N>> RectTrait for Node<'_, N, T> {
             x: self.max_x(),
             y: self.max_y(),
         }
+    }
+}
+
+impl<N: IndexableNum, T: RTreeIndex<N>> GeometryTrait for Node<'_, N, T> {
+    type T = N;
+
+    type PointType<'a>
+        = UnimplementedPoint<N>
+    where
+        Self: 'a;
+
+    type LineStringType<'a>
+        = UnimplementedLineString<N>
+    where
+        Self: 'a;
+
+    type PolygonType<'a>
+        = UnimplementedPolygon<N>
+    where
+        Self: 'a;
+
+    type MultiPointType<'a>
+        = UnimplementedMultiPoint<N>
+    where
+        Self: 'a;
+
+    type MultiLineStringType<'a>
+        = UnimplementedMultiLineString<N>
+    where
+        Self: 'a;
+
+    type MultiPolygonType<'a>
+        = UnimplementedMultiPolygon<N>
+    where
+        Self: 'a;
+
+    type GeometryCollectionType<'a>
+        = UnimplementedGeometryCollection<N>
+    where
+        Self: 'a;
+
+    type RectType<'a>
+        = Node<'a, N, T>
+    where
+        Self: 'a;
+
+    type TriangleType<'a>
+        = UnimplementedTriangle<N>
+    where
+        Self: 'a;
+
+    type LineType<'a>
+        = UnimplementedLine<N>
+    where
+        Self: 'a;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        geo_traits::Dimensions::Xy
+    }
+
+    fn as_type(
+        &self,
+    ) -> geo_traits::GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        geo_traits::GeometryType::Rect(self)
     }
 }
 


### PR DESCRIPTION
geo-traits 0.3.0 introduced [breaking changes](https://github.com/georust/geo/pull/1346), this patch upgrades the geo-traits dependency and adapted RectTrait implementation for `Node` types.

Additionally, the version of `geo` is also upgraded to latest release.