### PR TITLE
release: Bump version to 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **This is the changelog for the core Rust library**. There's a [separate changelog](./python/CHANGELOG.md) for the Python bindings.
 
-## Unreleased
+## [0.3.4] - 2026-02-27
 
 ### Bug fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "geo-index"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytemuck",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-index"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
 edition = "2021"
 rust-version = "1.75"


### PR DESCRIPTION
This PR updates the version number...I am hoping to release the version after https://github.com/georust/geo-index/pull/157 , which fixes a crash in a not uncommon case (previously sorted input). Open to thoughts!

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
